### PR TITLE
Add new API endpoint

### DIFF
--- a/pylon/plugins/test_api/api/v1/__init__.py
+++ b/pylon/plugins/test_api/api/v1/__init__.py
@@ -1,0 +1,8 @@
+from flask import Blueprint, jsonify
+
+bp = Blueprint('api_v1', __name__)
+
+@bp.route('/hello', methods=['GET'])
+def hello():
+    return jsonify({"ok": "hello"})
+


### PR DESCRIPTION
This pull request adds a new API endpoint in the `test_api` plugin. The endpoint returns a JSON response with `{ "ok": "hello" }` when accessed at `/hello`.