### PR TITLE
Add POST endpoint to echo back data

### DIFF
--- a/pylon/plugins/test_api/api/v1/metadata.py
+++ b/pylon/plugins/test_api/api/v1/metadata.py
@@ -1,6 +1,7 @@
 from flask_restful import Resource
 
 from pylon.core.tools import log
+from flask import request
 
 # from ...models.metadata import MetadataEntry
 
@@ -22,3 +23,14 @@ class API(Resource):
             return []  # TODO: list present keys
         # TODO: get data for key
         return {"error": "not implemented yet"}, 418
+    
+    def post(self, key=None):
+        """
+        Echo back posted data. If key is provided, include key in response.
+        """
+        data = request.get_json(silent=True)
+        if data is None:
+            data = request.get_data(as_text=True)
+        if key:
+            return {"key": key, "data": data}, 200
+        return data, 200


### PR DESCRIPTION
This PR introduces a POST endpoint in the metadata API to echo back posted data. Key highlights of the change:

- The endpoint accepts JSON or raw text data.
- If a key is provided in the URL, the response wraps the data with the key.
- Changes were made in the file `pylon/plugins/test_api/api/v1/metadata.py`.